### PR TITLE
Enable context menu

### DIFF
--- a/src/EnhancedScatterChart.ts
+++ b/src/EnhancedScatterChart.ts
@@ -662,7 +662,7 @@ export class EnhancedScatterChart implements IVisual {
             const mouseEvent: MouseEvent = getEvent();
             const eventTarget: EventTarget = mouseEvent.target;
             let dataPoint: any = d3.select(<d3.BaseType>eventTarget).datum();
-            this.selectionManager.showContextMenu(dataPoint ? dataPoint.selectionId : {}, {
+            this.selectionManager.showContextMenu(dataPoint ? dataPoint.identity : {}, {
                 x: mouseEvent.clientX,
                 y: mouseEvent.clientY
             });


### PR DESCRIPTION
Adjusted an invalid property reference which prevented context menu from showing on right-click in visual